### PR TITLE
Fix: frontend explorer doesn't know devnet

### DIFF
--- a/rhone-devnet/docker-compose.yml
+++ b/rhone-devnet/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     environment:
       - VITE_NODE_URL=http://localhost:22973
       - VITE_BACKEND_URL=http://localhost:9090
-      - VITE_NETWORK_TYPE=mainnet
+      - VITE_NETWORK_TYPE=testnet
 
   # grafana:
   #   image: grafana/grafana:7.2.1

--- a/rhone-devnet/docker-compose.yml
+++ b/rhone-devnet/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     environment:
       - VITE_NODE_URL=http://localhost:22973
       - VITE_BACKEND_URL=http://localhost:9090
-      - VITE_NETWORK_TYPE=devnet
+      - VITE_NETWORK_TYPE=mainnet
 
   # grafana:
   #   image: grafana/grafana:7.2.1


### PR DESCRIPTION
Error in browser console
```
Uncaught (in promise) Error: Value of the VITE_NETWORK_TYPE environment variable is invalid
    getClients http://127.0.0.1:23000/assets/App-0e23d4b3.js:87
    ML http://127.0.0.1:23000/assets/App-0e23d4b3.js:78
    <anonymous> http://127.0.0.1:23000/assets/App-0e23d4b3.js:87
```

