### PR TITLE
Update docker-compose.yml

### DIFF
--- a/devnet/docker-compose.yml
+++ b/devnet/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   alephium:
-    image: alephium/alephium:v3.2.0
+    image: alephium/alephium:v3.3.0
     restart: 'no'
     ports:
       - 19973:19973/tcp


### PR DESCRIPTION
En suivant le tutoriel, en clonant les fichiers j'ai eu un problème de mise à jour de version, ou il m'étais demandé la 3.3.0. Je propose ce changement qu'il faudrait faire sur npx @alephium/cli@latest init alephium-tutorial et également sur npx @alephium/cli@latest init alephium-nextjs-tutorial --template nextjs