### PR TITLE
Upgrade Node and Explorer Backend Versions

### DIFF
--- a/devnet/docker-compose.yml
+++ b/devnet/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   alephium:
-    image: alephium/alephium:v3.6.3
+    image: alephium/alephium:v3.7.0
     restart: 'no'
     ports:
       - 19973:19973/tcp
@@ -48,7 +48,7 @@ services:
     restart: unless-stopped
 
   explorer-backend:
-    image: alephium/explorer-backend:v1.19.4
+    image: alephium/explorer-backend:v2.2.3
     depends_on:
       postgres:
         condition: service_healthy

--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 
 services:
   alephium:
-    image: alephium/alephium:v3.6.3
+    image: alephium/alephium:v3.7.0
     restart: 'no'
     logging:
       driver: 'local'
@@ -65,7 +65,7 @@ services:
   #   restart: unless-stopped
 
   # explorer-backend:
-  #   image: alephium/explorer-backend:v1.19.4
+  #   image: alephium/explorer-backend:v2.2.3
   #   depends_on:
   #     postgres:
   #       condition: service_healthy

--- a/mainnet/full-node.yml
+++ b/mainnet/full-node.yml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   alephium:
-    image: alephium/alephium:v1.4.4
+    image: alephium/alephium:v3.7.0
     restart: unless-stopped
     ports:
       # 9973 (udp and tcp) is used for external p2p connection and must be exposed

--- a/mining-pool-local-testnet/docker-compose.yml
+++ b/mining-pool-local-testnet/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   alephium:
-    image: alephium/alephium:v3.6.3
+    image: alephium/alephium:v3.7.0
     restart: 'no'
     ports:
       - 19973:19973/tcp
@@ -48,7 +48,7 @@ services:
     restart: unless-stopped
 
   explorer-backend:
-    image: alephium/explorer-backend:v1.19.1
+    image: alephium/explorer-backend:v2.2.3
     depends_on:
       postgres:
         condition: service_healthy

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 
 services:
   alephium:
-    image: alephium/alephium:v3.6.3
+    image: alephium/alephium:v3.7.0
     restart: 'no'
     logging:
       driver: 'local'
@@ -65,7 +65,7 @@ services:
   #   restart: unless-stopped
 
   # explorer-backend:
-  #   image: alephium/explorer-backend:v1.19.4
+  #   image: alephium/explorer-backend:v2.2.3
   #   depends_on:
   #     postgres:
   #       condition: service_healthy


### PR DESCRIPTION
Upgrade node version to `2.7.0`, explorer-backend version to `2.2.3`.