### PR TITLE
Upgrade docker-compose.yml to ensure compatibility with Node 3.8.0

### DIFF
--- a/devnet/docker-compose.yml
+++ b/devnet/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   alephium:
-    image: alephium/alephium:v3.7.0
+    image: alephium/alephium:v3.8.0
     restart: 'no'
     ports:
       - 19973:19973/tcp


### PR DESCRIPTION
This commit updates the docker-compose.yml to the latest image version (3.8.0) to address compatibility issues with Node version 3.7.0. The current version of alephium-cli had mismatches when used alongside Node 3.7.0, as highlighted in the latest documentation. This update ensures seamless integration and prevents potential compile errors.